### PR TITLE
feat(helm): make liveness probe timings configurable and update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Kubernetes: `>= 1.14.0-0`
 | global.searchEngine.semanticIndexer.knnVectorFieldConfig.m | int | `16` | The maximum number of graph edges per vector. Higher values increase memory usage but may improve search quality. |
 | global.searchEngine.semanticIndexer.knnVectorFieldConfig.mode | string | `"on_disk"` | Vector workload mode: `on_disk` or `in_memory`. |
 | image.name | string | `"magda-pdf-semantic-indexer"` |  |
+| livenessProbe | object | `{"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":60}` | Liveness probe settings. |
+| livenessProbe.initialDelaySeconds | int | `10` | Seconds after container start before probes begin. |
+| livenessProbe.periodSeconds | int | `10` | Seconds between liveness probes. |
+| livenessProbe.timeoutSeconds | int | `60` | Probe timeout in seconds. |
 | minioConfig.defaultDatasetBucket | string | `""` |  |
 | minioConfig.endPoint | string | `"magda-minio"` |  |
 | minioConfig.port | int | `9000` |  |
@@ -49,10 +53,7 @@ Kubernetes: `>= 1.14.0-0`
 | minioConfig.useSSL | bool | `false` |  |
 | opensearchURL | string | `"http://opensearch:9200"` |  |
 | port | int | `6305` | Service port configuration |
-| resources.limits.cpu | string | `"500m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"200Mi"` |  |
+| resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"200Mi"}}` | Container resources for the indexer pod. |
 | semanticIndexer.bulkEmbeddingsSize | int | `nil` | number of string we request embedding api to process in one request |
 | semanticIndexer.bulkIndexSize | int | `nil` | Number of documents we send to OpenSearch for bulk processing in a single request |
 | semanticIndexer.chunkSizeLimit | int | `nil` | The maximum number of tokens in a single chunk. |

--- a/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
+++ b/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
@@ -37,11 +37,11 @@ spec:
 {{- if .Values.global.enableLivenessProbes }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbePath | quote }}
-            port: {{ .Values.livenessProbePort | default .Values.port }}
-          initialDelaySeconds: {{ .Values.livenessProbeInitialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbePeriodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }}
+            path: "/healthz"
+            port: {{ .Values.port }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
+++ b/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
@@ -15,6 +15,55 @@ spec:
       labels:
         service: magda-pdf-semantic-indexer
     spec:
+      {{- $config := .Values.config | default dict }}
+      {{- $resources := .Values.resources }}
+      {{- if and (hasKey $config "resources") (ne (get $config "resources") nil) }}
+      {{- $resources = (get $config "resources") }}
+      {{- end }}
+      {{- $livenessProbe := .Values.livenessProbe | default dict }}
+      {{- $configLivenessProbe := (get $config "livenessProbe") | default dict }}
+      {{- $livenessProbeEnabled := .Values.global.enableLivenessProbes | default false }}
+      {{- if and (hasKey $livenessProbe "enabled") (ne (get $livenessProbe "enabled") nil) }}
+      {{- $livenessProbeEnabled = (get $livenessProbe "enabled") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "enabled") (ne (get $configLivenessProbe "enabled") nil) }}
+      {{- $livenessProbeEnabled = (get $configLivenessProbe "enabled") }}
+      {{- end }}
+      {{- $livenessProbePath := "/healthz" }}
+      {{- if and (hasKey $livenessProbe "path") (ne (get $livenessProbe "path") nil) }}
+      {{- $livenessProbePath = (get $livenessProbe "path") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "path") (ne (get $configLivenessProbe "path") nil) }}
+      {{- $livenessProbePath = (get $configLivenessProbe "path") }}
+      {{- end }}
+      {{- $livenessProbePort := .Values.port }}
+      {{- if and (hasKey $livenessProbe "port") (ne (get $livenessProbe "port") nil) }}
+      {{- $livenessProbePort = (get $livenessProbe "port") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "port") (ne (get $configLivenessProbe "port") nil) }}
+      {{- $livenessProbePort = (get $configLivenessProbe "port") }}
+      {{- end }}
+      {{- $livenessProbeInitialDelaySeconds := 10 }}
+      {{- if and (hasKey $livenessProbe "initialDelaySeconds") (ne (get $livenessProbe "initialDelaySeconds") nil) }}
+      {{- $livenessProbeInitialDelaySeconds = (get $livenessProbe "initialDelaySeconds") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "initialDelaySeconds") (ne (get $configLivenessProbe "initialDelaySeconds") nil) }}
+      {{- $livenessProbeInitialDelaySeconds = (get $configLivenessProbe "initialDelaySeconds") }}
+      {{- end }}
+      {{- $livenessProbePeriodSeconds := 10 }}
+      {{- if and (hasKey $livenessProbe "periodSeconds") (ne (get $livenessProbe "periodSeconds") nil) }}
+      {{- $livenessProbePeriodSeconds = (get $livenessProbe "periodSeconds") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "periodSeconds") (ne (get $configLivenessProbe "periodSeconds") nil) }}
+      {{- $livenessProbePeriodSeconds = (get $configLivenessProbe "periodSeconds") }}
+      {{- end }}
+      {{- $livenessProbeTimeoutSeconds := 10 }}
+      {{- if and (hasKey $livenessProbe "timeoutSeconds") (ne (get $livenessProbe "timeoutSeconds") nil) }}
+      {{- $livenessProbeTimeoutSeconds = (get $livenessProbe "timeoutSeconds") }}
+      {{- end }}
+      {{- if and (hasKey $configLivenessProbe "timeoutSeconds") (ne (get $configLivenessProbe "timeoutSeconds") nil) }}
+      {{- $livenessProbeTimeoutSeconds = (get $configLivenessProbe "timeoutSeconds") }}
+      {{- end }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}
       containers:
       - name: magda-pdf-semantic-indexer
@@ -34,17 +83,17 @@ spec:
         ports:
         - containerPort: {{ int .Values.port }}
           name: http
-{{- if .Values.global.enableLivenessProbes }}
+{{- if $livenessProbeEnabled }}
         livenessProbe:
           httpGet:
-            path: "/healthz"
-            port: {{ .Values.port }}
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 10
+            path: {{ $livenessProbePath | quote }}
+            port: {{ $livenessProbePort }}
+          initialDelaySeconds: {{ $livenessProbeInitialDelaySeconds }}
+          periodSeconds: {{ $livenessProbePeriodSeconds }}
+          timeoutSeconds: {{ $livenessProbeTimeoutSeconds }}
 {{- end }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml $resources | indent 10 }}
         env:
         - name: NODE_PORT
           value: {{ .Values.port | quote }}

--- a/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
+++ b/deploy/magda-pdf-semantic-indexer/templates/deployment.yaml
@@ -15,55 +15,6 @@ spec:
       labels:
         service: magda-pdf-semantic-indexer
     spec:
-      {{- $config := .Values.config | default dict }}
-      {{- $resources := .Values.resources }}
-      {{- if and (hasKey $config "resources") (ne (get $config "resources") nil) }}
-      {{- $resources = (get $config "resources") }}
-      {{- end }}
-      {{- $livenessProbe := .Values.livenessProbe | default dict }}
-      {{- $configLivenessProbe := (get $config "livenessProbe") | default dict }}
-      {{- $livenessProbeEnabled := .Values.global.enableLivenessProbes | default false }}
-      {{- if and (hasKey $livenessProbe "enabled") (ne (get $livenessProbe "enabled") nil) }}
-      {{- $livenessProbeEnabled = (get $livenessProbe "enabled") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "enabled") (ne (get $configLivenessProbe "enabled") nil) }}
-      {{- $livenessProbeEnabled = (get $configLivenessProbe "enabled") }}
-      {{- end }}
-      {{- $livenessProbePath := "/healthz" }}
-      {{- if and (hasKey $livenessProbe "path") (ne (get $livenessProbe "path") nil) }}
-      {{- $livenessProbePath = (get $livenessProbe "path") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "path") (ne (get $configLivenessProbe "path") nil) }}
-      {{- $livenessProbePath = (get $configLivenessProbe "path") }}
-      {{- end }}
-      {{- $livenessProbePort := .Values.port }}
-      {{- if and (hasKey $livenessProbe "port") (ne (get $livenessProbe "port") nil) }}
-      {{- $livenessProbePort = (get $livenessProbe "port") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "port") (ne (get $configLivenessProbe "port") nil) }}
-      {{- $livenessProbePort = (get $configLivenessProbe "port") }}
-      {{- end }}
-      {{- $livenessProbeInitialDelaySeconds := 10 }}
-      {{- if and (hasKey $livenessProbe "initialDelaySeconds") (ne (get $livenessProbe "initialDelaySeconds") nil) }}
-      {{- $livenessProbeInitialDelaySeconds = (get $livenessProbe "initialDelaySeconds") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "initialDelaySeconds") (ne (get $configLivenessProbe "initialDelaySeconds") nil) }}
-      {{- $livenessProbeInitialDelaySeconds = (get $configLivenessProbe "initialDelaySeconds") }}
-      {{- end }}
-      {{- $livenessProbePeriodSeconds := 10 }}
-      {{- if and (hasKey $livenessProbe "periodSeconds") (ne (get $livenessProbe "periodSeconds") nil) }}
-      {{- $livenessProbePeriodSeconds = (get $livenessProbe "periodSeconds") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "periodSeconds") (ne (get $configLivenessProbe "periodSeconds") nil) }}
-      {{- $livenessProbePeriodSeconds = (get $configLivenessProbe "periodSeconds") }}
-      {{- end }}
-      {{- $livenessProbeTimeoutSeconds := 10 }}
-      {{- if and (hasKey $livenessProbe "timeoutSeconds") (ne (get $livenessProbe "timeoutSeconds") nil) }}
-      {{- $livenessProbeTimeoutSeconds = (get $livenessProbe "timeoutSeconds") }}
-      {{- end }}
-      {{- if and (hasKey $configLivenessProbe "timeoutSeconds") (ne (get $configLivenessProbe "timeoutSeconds") nil) }}
-      {{- $livenessProbeTimeoutSeconds = (get $configLivenessProbe "timeoutSeconds") }}
-      {{- end }}
       {{- include "magda.imagePullSecrets" . | indent 6 }}
       containers:
       - name: magda-pdf-semantic-indexer
@@ -83,17 +34,17 @@ spec:
         ports:
         - containerPort: {{ int .Values.port }}
           name: http
-{{- if $livenessProbeEnabled }}
+{{- if .Values.global.enableLivenessProbes }}
         livenessProbe:
           httpGet:
-            path: {{ $livenessProbePath | quote }}
-            port: {{ $livenessProbePort }}
-          initialDelaySeconds: {{ $livenessProbeInitialDelaySeconds }}
-          periodSeconds: {{ $livenessProbePeriodSeconds }}
-          timeoutSeconds: {{ $livenessProbeTimeoutSeconds }}
+            path: {{ .Values.livenessProbePath | quote }}
+            port: {{ .Values.livenessProbePort | default .Values.port }}
+          initialDelaySeconds: {{ .Values.livenessProbeInitialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbePeriodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }}
 {{- end }}
         resources:
-{{ toYaml $resources | indent 10 }}
+{{ toYaml .Values.resources | indent 10 }}
         env:
         - name: NODE_PORT
           value: {{ .Values.port | quote }}

--- a/deploy/magda-pdf-semantic-indexer/values.yaml
+++ b/deploy/magda-pdf-semantic-indexer/values.yaml
@@ -87,8 +87,8 @@ resources:
     cpu: 100m
     memory: 200Mi
   limits:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 1000m
+    memory: 1024Mi
 
 # -- Liveness probe settings.
 livenessProbe:
@@ -97,4 +97,4 @@ livenessProbe:
   # -- Seconds between liveness probes.
   periodSeconds: 10
   # -- Probe timeout in seconds.
-  timeoutSeconds: 10
+  timeoutSeconds: 60

--- a/deploy/magda-pdf-semantic-indexer/values.yaml
+++ b/deploy/magda-pdf-semantic-indexer/values.yaml
@@ -90,13 +90,11 @@ resources:
     cpu: 500m
     memory: 512Mi
 
-# -- HTTP path for liveness checks.
-livenessProbePath: "/healthz"
-# -- Optional liveness probe port override. If empty, `port` is used.
-livenessProbePort:
-# -- Seconds after container start before probes begin.
-livenessProbeInitialDelaySeconds: 10
-# -- Seconds between liveness probes.
-livenessProbePeriodSeconds: 10
-# -- Probe timeout in seconds.
-livenessProbeTimeoutSeconds: 10
+# -- Liveness probe settings.
+livenessProbe:
+  # -- Seconds after container start before probes begin.
+  initialDelaySeconds: 10
+  # -- Seconds between liveness probes.
+  periodSeconds: 10
+  # -- Probe timeout in seconds.
+  timeoutSeconds: 10

--- a/deploy/magda-pdf-semantic-indexer/values.yaml
+++ b/deploy/magda-pdf-semantic-indexer/values.yaml
@@ -90,22 +90,13 @@ resources:
     cpu: 500m
     memory: 512Mi
 
-# -- Optional compatibility aliases for values injected under `config.*`.
-config:
-  resources:
-  livenessProbe:
-
-# -- Liveness probe settings for the indexer pod.
-livenessProbe:
-  # -- Optional explicit enable/disable override. If unset, falls back to `global.enableLivenessProbes`.
-  enabled:
-  # -- HTTP path for liveness checks.
-  path: "/healthz"
-  # -- Optional probe port override. If unset, uses `port`.
-  port:
-  # -- Seconds after container start before probes begin.
-  initialDelaySeconds: 10
-  # -- Seconds between liveness probes.
-  periodSeconds: 10
-  # -- Probe timeout in seconds.
-  timeoutSeconds: 10
+# -- HTTP path for liveness checks.
+livenessProbePath: "/healthz"
+# -- Optional liveness probe port override. If empty, `port` is used.
+livenessProbePort:
+# -- Seconds after container start before probes begin.
+livenessProbeInitialDelaySeconds: 10
+# -- Seconds between liveness probes.
+livenessProbePeriodSeconds: 10
+# -- Probe timeout in seconds.
+livenessProbeTimeoutSeconds: 10

--- a/deploy/magda-pdf-semantic-indexer/values.yaml
+++ b/deploy/magda-pdf-semantic-indexer/values.yaml
@@ -81,6 +81,7 @@ defaultImage:
 
 defaultAdminUserId: "00000000-0000-4000-8000-000000000000"
 
+# -- Container resources for the indexer pod.
 resources:
   requests:
     cpu: 100m
@@ -88,3 +89,23 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+
+# -- Optional compatibility aliases for values injected under `config.*`.
+config:
+  resources:
+  livenessProbe:
+
+# -- Liveness probe settings for the indexer pod.
+livenessProbe:
+  # -- Optional explicit enable/disable override. If unset, falls back to `global.enableLivenessProbes`.
+  enabled:
+  # -- HTTP path for liveness checks.
+  path: "/healthz"
+  # -- Optional probe port override. If unset, uses `port`.
+  port:
+  # -- Seconds after container start before probes begin.
+  initialDelaySeconds: 10
+  # -- Seconds between liveness probes.
+  periodSeconds: 10
+  # -- Probe timeout in seconds.
+  timeoutSeconds: 10


### PR DESCRIPTION
## Summary
- keep liveness probe path and port fixed in template:
  - `path: "/healthz"`
  - `port: {{ .Values.port }}`
- make liveness probe timing fields configurable under nested `livenessProbe` values:
  - `livenessProbe.initialDelaySeconds`
  - `livenessProbe.periodSeconds`
  - `livenessProbe.timeoutSeconds`
- update defaults:
  - `livenessProbe.timeoutSeconds` from `10` to `60`
  - `resources.limits.cpu` from `500m` to `1000m`
  - `resources.limits.memory` from `512Mi` to `1024Mi`
- regenerate Helm chart docs (`README.md`) via `yarn helm-docs`

## Test Plan
- `helm lint deploy/magda-pdf-semantic-indexer`
- `helm template test deploy/magda-pdf-semantic-indexer --set global.enableLivenessProbes=true --set livenessProbe.initialDelaySeconds=15 --set livenessProbe.periodSeconds=20 --set livenessProbe.timeoutSeconds=3`
- `helm template test deploy/magda-pdf-semantic-indexer --set global.enableLivenessProbes=true --set port=6401`
- `yarn helm-docs`